### PR TITLE
Add narrow tab option

### DIFF
--- a/Gravity One/Gravity One.sublime-theme
+++ b/Gravity One/Gravity One.sublime-theme
@@ -9,7 +9,7 @@
         "layer0.opacity": 1.0,
         "content_margin": [0, 0, 0, 0],
         "tab_overlap": 1,
-        "tab_width": 300,
+        // "tab_width": 300,
         "tab_min_width": 70,
         // "tab_height": 35,
         "mouse_wheel_switch": false
@@ -671,7 +671,8 @@
 
     {
         "class": "tabset_control",
-        "tab_height": 41
+        "tab_height": 41,
+        "tab_width": 300
     },
     {
         "class": "tabset_control",
@@ -682,6 +683,11 @@
         "class": "tabset_control",
         "settings": ["gravity_tab_height_tall"],
         "tab_height": 47
+    },
+    {
+        "class": "tabset_control",
+        "settings": ["gravity_tab_width_narrow"],
+        "tab_width": 220
     },
     {
         "class": "tabset_control",

--- a/Gravity/Gravity.sublime-theme
+++ b/Gravity/Gravity.sublime-theme
@@ -9,7 +9,7 @@
         "layer0.opacity": 1.0,
         "content_margin": [0, 0, 0, 0],
         "tab_overlap": 1,
-        "tab_width": 300,
+        // "tab_width": 300,
         "tab_min_width": 70,
         // "tab_height": 35,
         "mouse_wheel_switch": false
@@ -675,7 +675,8 @@
 
     {
         "class": "tabset_control",
-        "tab_height": 41
+        "tab_height": 41,
+        "tab_width": 300
     },
     {
         "class": "tabset_control",
@@ -686,6 +687,11 @@
         "class": "tabset_control",
         "settings": ["gravity_tab_height_tall"],
         "tab_height": 47
+    },
+    {
+        "class": "tabset_control",
+        "settings": ["gravity_tab_width_narrow"],
+        "tab_width": 220
     },
     {
         "class": "tabset_control",

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ If you're using [Package Control](https://sublime.wbond.net), you can easily ins
 * And add:
 `"gravity_tab_height_tall": true` or `"gravity_tab_height_short": true`
 
+**Applying the file Tab width option:**
+
+* Open your settings (if not already open) by using the menu `Preferences > Settings - User` and add:
+`"gravity_tab_width_narrow": true`
+
 **Applying the blue hightlight color option:**
 
 * Open your settings (if not already open) by using the menu `Preferences > Settings - User` and add:

--- a/Reverse Gravity/Reverse Gravity.sublime-theme
+++ b/Reverse Gravity/Reverse Gravity.sublime-theme
@@ -9,7 +9,7 @@
         "layer0.opacity": 1.0,
         "content_margin": [0, 0, 0, 0],
         "tab_overlap": 1,
-        "tab_width": 300,
+        // "tab_width": 300,
         "tab_min_width": 70,
         // "tab_height": 35,
         "mouse_wheel_switch": false
@@ -672,7 +672,8 @@
 
     {
         "class": "tabset_control",
-        "tab_height": 39
+        "tab_height": 39,
+        "tab_width": 300
     },
     {
         "class": "tabset_control",
@@ -683,6 +684,11 @@
         "class": "tabset_control",
         "settings": ["gravity_tab_height_tall"],
         "tab_height": 45
+    },
+    {
+        "class": "tabset_control",
+        "settings": ["gravity_tab_width_narrow"],
+        "tab_width": 220
     },
     {
         "class": "tabset_control",


### PR DESCRIPTION
This adds a `gravity_tab_width_narrow` configuration option that reduces the default file tab width from 300 to 220.