### PR TITLE
Reduce status bar height

### DIFF
--- a/Reverse Gravity/Reverse Gravity.sublime-theme
+++ b/Reverse Gravity/Reverse Gravity.sublime-theme
@@ -739,7 +739,7 @@
 
     {
         "class": "status_bar",
-        "content_margin": [14, 6, 4, 5],
+        "content_margin": [14, 0, 4, 0],
         "layer0.inner_margin": 0,
         "layer0.tint": [222, 222, 222],
         "layer0.opacity": 1.0,


### PR DESCRIPTION
Status bar height has become insanely large.

Caveats:
- I'm not familiar with theme edits, perhaps it could be provided as an option?
- Only applied the change on `Reverse Gravity` for now

## Before

<img width="1125" alt="image" src="https://user-images.githubusercontent.com/297345/57019404-ab4cb980-6c26-11e9-94a1-2ea0db1c25d1.png">

## After

<img width="1125" alt="image" src="https://user-images.githubusercontent.com/297345/57019375-96702600-6c26-11e9-9ddf-1ab6798ad83b.png">
